### PR TITLE
augment /vendor/etc/mixer_path_0.xml to allow recording

### DIFF
--- a/configs/audio/mixer_paths_0.xml
+++ b/configs/audio/mixer_paths_0.xml
@@ -410,4 +410,55 @@ INPUT_CHANNEL_MAP {
       <!-- Empty path -->
   </path>
 
+  <!-- Samsung OSS audio HAL custom paths -->
+
+  <!-- Input -->
+  <path name="earpiece-mic">
+    <path name="media-main-mic"/>
+  </path>
+
+  <path name="speaker-mic">
+    <path name="media-main-mic"/>
+  </path>
+
+  <path name="headset-mic">
+    <path name="voice-headset-mic"/>
+  </path>
+
+  <path name="voice-mic">
+    <path name="media-main-mic"/>
+  </path>
+
+  <path name="voice-earpiece-mic">
+    <path name="media-main-mic"/>
+  </path>
+
+  <path name="voice-earpiece-mic-wb">
+    <path name="media-main-mic"/>
+  </path>
+
+  <path name="voice-speaker-mic">
+    <path name="media-main-mic"/>
+  </path>
+
+  <path name="voice-speaker-mic-wb">
+    <path name="media-main-mic"/>
+  </path>
+
+  <path name="voice-headset-mic-wb">
+    <path name="voice-headset-mic"/>
+  </path>
+
+  <path name="voice-bt-sco-mic">
+    <path name="bt-sco-mic"/>
+  </path>
+
+  <path name="voice-bt-sco-mic-wb">
+    <path name="bt-sco-mic"/>
+  </path>
+
+  <path name="voice-rec-mic">
+    <path name="voice-rec-main-mic"/>
+  </path>
+
 </mixer>


### PR DESCRIPTION
this mixer_path patch enables the microphone in v2awifi in LineageOS 17.1 (/e/OS-q)